### PR TITLE
Increase page navigation timeout from 60s to 120s

### DIFF
--- a/puppeteer-download.js
+++ b/puppeteer-download.js
@@ -39,7 +39,7 @@ const downloadPage = async (url) => {
 
 	await page.goto(url, {
 		waitUntil: 'networkidle2',
-		timeout: 60000,
+		timeout: 120000,
 	})
 
 	try {
@@ -63,7 +63,7 @@ const downloadBuffer = async (url) => {
 
 	const response = await page.goto(url, {
 		waitUntil: 'networkidle2',
-		timeout: 60000,
+		timeout: 120000,
 	})
 
 	if (!response || !response.ok()) {


### PR DESCRIPTION
## Summary
Increased the page navigation timeout in both `downloadPage` and `downloadBuffer` functions from 60 seconds to 120 seconds to allow more time for pages to load before timing out.

## Changes
- Updated `downloadPage()` function timeout from 60000ms to 120000ms
- Updated `downloadBuffer()` function timeout from 60000ms to 120000ms

## Details
Both functions use Puppeteer's `page.goto()` method with a `waitUntil: 'networkidle2'` condition. The doubled timeout provides additional buffer for slower network conditions or pages with heavy resource loading, reducing the likelihood of premature timeout failures during page navigation.

https://claude.ai/code/session_018Lpj95wz9rH7gyCrhpp3oa